### PR TITLE
fix bug

### DIFF
--- a/client/src/components/Search/Search.jsx
+++ b/client/src/components/Search/Search.jsx
@@ -20,7 +20,7 @@ class Search extends React.Component {
     }
 
     onButtonClick() {
-        const {onSearch} = props;
+        const {onSearch} = this.props;
         const searchTerm = this.state.searchTerm;
 
         onSearch(searchTerm);


### PR DESCRIPTION
this is a stateful component, props are accessed from the instance. ```this.props``` is the correct way